### PR TITLE
Remove patreon link

### DIFF
--- a/templates/common/layout_nav.twig
+++ b/templates/common/layout_nav.twig
@@ -90,11 +90,6 @@
                         #}<i class="fa social-media fa-twitter"></i> SoatokDhole{#
                     #}</a>
                 </li>
-                <li title="Patreon">
-                    <a href="https://www.patreon.com/soatok" rel="noopener">{#
-                        <i class="fa social-media fa-patreon"></i>#}Patreon: soatok{#
-                    #}</a>
-                </li>
             </ul>
         </li>
         <li><a href="https://github.com/soatok/website" rel="noopener">Website Source Code</a></li>


### PR DESCRIPTION
To prevent anyone from getting confused as you deleted your patreon as per https://soatok.blog/2022/09/09/should-you-delete-your-patreon-account-after-they-laid-off-their-entire-security-team/