### PR TITLE
Replace old Twitter entries with Mastodon ones

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # Soatok's Website
 
-This is the software that powers the personal website of [Soatok Dreamseeker](https://twitter.com/SoatokDhole).
+This is the software that powers the personal website of [Soatok Dreamseeker](https://furry.engineer/@soatok).

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     {
       "name": "Soatok Dreamseeker",
       "role": "Developer",
-      "homepage": "https://twitter.com/SoatokDhole"
+      "homepage": "https://furry.engineer/@soatok"
     }
   ],
   "require": {

--- a/templates/common/layout_nav.twig
+++ b/templates/common/layout_nav.twig
@@ -85,9 +85,9 @@
                         #}<i class="fa social-media fa-twitch"></i> Soatok{#
                     #}</a>
                 </li>
-                <li title="Twitter">
-                    <a href="https://twitter.com/SoatokDhole" rel="noopener">{#
-                        #}<i class="fa social-media fa-twitter"></i> SoatokDhole{#
+                <li title="Mastodon">
+                    <a href="https://furry.engineer/@soatok" rel="noopener">{#
+                        #}Mastodon: Soatok{#
                     #}</a>
                 </li>
             </ul>

--- a/templates/soatok.com/pages/freelance.twig
+++ b/templates/soatok.com/pages/freelance.twig
@@ -38,7 +38,7 @@
 
     <p>
         If you'd like to discuss working together, please feel free to reach out to me
-        via Telegram, Twitter, or FurAffinity.
+        via Telegram, Mastodon, or FurAffinity.
     </p>
     <p>If you'd like to contact me by email, my
         GPG public key is <a href="static/gpg-public-key.txt">available here</a>.


### PR DESCRIPTION
No need to point future disciples to inactive accounts on Twitter. Let's use the main active one!

I did not do any work regarding Font Awesome supporting Mastodon icon so far. Therefore, instead of a cute icon, there's just text.